### PR TITLE
Operator not working on OpenShift

### DIFF
--- a/pkg/controller/distributedrediscluster/sync_handler.go
+++ b/pkg/controller/distributedrediscluster/sync_handler.go
@@ -352,9 +352,9 @@ func (r *ReconcileDistributedRedisCluster) resetClusterPassword(ctx *syncContext
 		}
 		defer admin.Close()
 
-		// Update the password recorded in the file /etc/redis_password, redis pod preStop hook
-		// need /etc/redis_password do CLUSTER FAILOVER
-		cmd := fmt.Sprintf("echo %s > /etc/redis_password", newPassword)
+		// Update the password recorded in the file /data/redis_password, redis pod preStop hook
+		// need /data/redis_password do CLUSTER FAILOVER
+		cmd := fmt.Sprintf("echo %s > /data/redis_password", newPassword)
 		if err := r.execer.ExecCommandInPodSet(podSet, "/bin/sh", "-c", cmd); err != nil {
 			return err
 		}

--- a/pkg/resources/configmaps/configmap.go
+++ b/pkg/resources/configmaps/configmap.go
@@ -29,7 +29,7 @@ failover() {
 	echo "Master: ${masterID}"
 	slave=$(cat ${CLUSTER_CONFIG} | grep ${masterID} | grep "slave" | awk 'NR==1{print $2}' | sed 's/:6379@16379//')
 	echo "Slave: ${slave}"
-	password=$(cat /etc/redis_password)
+	password=$(cat /data/redis_password)
 	if [[ -z "${password}" ]]; then
 		redis-cli -h ${slave} CLUSTER FAILOVER
 	else

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -260,7 +260,7 @@ func redisServerContainer(cluster *redisv1alpha1.DistributedRedisCluster, passwo
 		Lifecycle: &corev1.Lifecycle{
 			PostStart: &corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"/bin/sh", "-c", "echo ${REDIS_PASSWORD} > /etc/redis_password"},
+					Command: []string{"/bin/sh", "-c", "echo ${REDIS_PASSWORD} > /data/redis_password"},
 				},
 			},
 			PreStop: &corev1.Handler{


### PR DESCRIPTION
/etc/redis_password -> /data/redis_password
/etc is read-only on OpenShift. Maybe there are better fixes but this works. /conf is also read-only.

Fix #47