### PR TITLE
apiextensions.k8s.io/v1

### DIFF
--- a/deploy/crds/redis.kun_distributedredisclusters_crd_V1.22.yaml
+++ b/deploy/crds/redis.kun_distributedredisclusters_crd_V1.22.yaml
@@ -1,0 +1,79 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: distributedredisclusters.redis.kun
+spec:
+  group: redis.kun
+  names:
+    kind: DistributedRedisCluster
+    listKind: DistributedRedisClusterList
+    plural: distributedredisclusters
+    singular: distributedrediscluster
+    shortNames:
+    - drc
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+      - jsonPath: .spec.masterSize
+        description: The number of redis master node in the ensemble
+        name: MasterSize
+        type: integer
+      - jsonPath: .status.status
+        description: The status of redis cluster
+        name: Status
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      - jsonPath: .status.numberOfMaster
+        priority: 1
+        description: The current master number of redis cluster
+        name: CurrentMasters
+        type: integer
+      - jsonPath: .spec.image
+        priority: 1
+        description: The image of redis cluster
+        name: Images
+        type: string
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: DistributedRedisCluster is the Schema for the distributedredisclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DistributedRedisClusterSpec defines the desired state of DistributedRedisCluster
+            properties:
+              masterSize:
+                format: int32
+                type: integer
+                minimum: 3
+                maximum: 10
+              clusterReplicas:
+                format: int32
+                type: integer
+                minimum: 1
+                maximum: 3
+              serviceName:
+                type: string
+                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+            type: object
+          status:
+            description: DistributedRedisClusterStatus defines the observed state of DistributedRedisCluster
+            type: object
+        type: object

--- a/deploy/crds/redis.kun_redisclusterbackups_crd_V1.22.yaml
+++ b/deploy/crds/redis.kun_redisclusterbackups_crd_V1.22.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: redisclusterbackups.redis.kun
+spec:
+  group: redis.kun
+  names:
+    kind: RedisClusterBackup
+    listKind: RedisClusterBackupList
+    plural: redisclusterbackups
+    singular: redisclusterbackup
+    shortNames:
+      - drcb
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      - jsonPath: .status.phase
+        description: The phase of redis cluster backup
+        name: Phase
+        type: string
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: RedisClusterBackup is the Schema for the redisclusterbackups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RedisClusterBackupSpec defines the desired state of RedisClusterBackup
+            type: object
+          status:
+            description: RedisClusterBackupStatus defines the observed state of RedisClusterBackup
+            type: object
+        type: object


### PR DESCRIPTION
The apiextensions.k8s.io/v1beta1 API version of CustomResourceDefinition is no longer served as of v1.22.